### PR TITLE
Initial Code for the Local API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__/
 logs/
 **.pyc
+data/
+articles.pickle.tmp

--- a/HeuristicTester.py
+++ b/HeuristicTester.py
@@ -10,8 +10,8 @@ log = logging.getLogger(__name__)
 
 class HeuristicTester:
     @staticmethod
-    def compare_heuristics(start, stop, *args):
-        agent = WikiAgent.WikiAgent()
+    def compare_heuristics(start, stop, api, *args):
+        agent = WikiAgent.WikiAgent(api)
         results = []
         for heuristic in args:
             log.info("Testing heuristic {} with start {} and end {}"

--- a/IWikiApi.py
+++ b/IWikiApi.py
@@ -1,0 +1,44 @@
+class IWikiApi:
+    """
+    Interface for Wikipedia APIs
+    """
+    
+    def load(self):
+        """
+        Does whatever loading the API need to do. This method is expected to potentially take some time.
+        By default does nothing, but can be overridden if the subclass needs to do some set up.
+        """
+        pass
+            
+    def get_random_page(self):
+        """
+        Return a random page
+        """
+        raise Error("Method not implemented")
+
+    def get_summaries(self, titles):
+        """
+        Bulk fetch summaries for a list of titles
+
+        Follows redirects
+
+        :param titles: A list of article titles
+        :return: A dict of titles to summary strings
+        """
+        raise Error("Method not implemented")
+
+    def get_text_and_links(self, title):
+        """
+        Return a tuple of (article text, link targets)
+
+        Follows redirects
+        """
+        raise Error("Method not implemented")
+
+    def get_canonical_name(self, title):
+        """
+        Get the official name of an article. Useful because we just check string equality for the goal test,
+        so we don't want to skip over the goal if e.g. the capitalization is off
+        :return: The canonical name of the given page
+        """
+        raise Error("Method not implemented")

--- a/IWikiApi.py
+++ b/IWikiApi.py
@@ -2,14 +2,26 @@ class IWikiApi:
     """
     Interface for Wikipedia APIs
     """
-    
+
     def load(self):
         """
         Does whatever loading the API need to do. This method is expected to potentially take some time.
         By default does nothing, but can be overridden if the subclass needs to do some set up.
         """
         pass
-            
+
+    def is_valid_article(self, title):
+        """
+        Return True IFF the page has a canonical name.
+        
+        TODO This should be memoized which would improve performance a ton.
+        """
+        try:
+            self.get_canonical_name(title)
+            return True
+        except IOError:
+            return False
+
     def get_random_page(self):
         """
         Return a random page

--- a/LocalApi.py
+++ b/LocalApi.py
@@ -61,7 +61,7 @@ class WikipediaIndexFile:
             with open("articles.pickle.tmp", "rb") as articles_pickle_file:
                 log.debug("Using pickled article file")
                 self.articles = pickle.load(articles_pickle_file)
-        except:
+        except IOError:
             log.debug("Unable to use pickled articles, doing a manual load of the index file")
             self.manual_load()
             with open("articles.pickle.tmp", "wb") as articles_pickle_file:

--- a/LocalApi.py
+++ b/LocalApi.py
@@ -1,0 +1,242 @@
+import logging
+import bz2
+import pickletools
+import itertools
+import xml.etree.ElementTree as xml
+import mwparserfromhell
+from titlecase import titlecase
+from os.path import getsize
+from IWikiApi import IWikiApi
+
+log = logging.getLogger(__name__)
+
+class WikipediaIndexFile:
+    """
+    A class to represent the index file provided with the data dump
+    The index file is a sequence of lines, each of the form:
+    BZ2_OFFSET:ARTICLE_ID:ARTICLE_TITLE
+
+    When we read the index file, we want to keep track of the ARTICLE_TITLE and the BZ2_OFFSET.
+    Articles are arranged in groups with the same BZ2_OFFSET,
+    and we need to know the BZ2_OFFSET of the group and the BZ2_OFFSET of the group after.
+
+    This allows us to take a clipping of the BZ2 file to decompress.
+    """
+    def __init__(self, index_file, xml_file_size):
+        self.index_file = index_file
+        self.xml_file_size = xml_file_size
+        self.articles = {}
+
+    def manual_load(self):
+        """
+        Read through the index file and build up a map from article titles to tuples of the form (chunk_start, chunk_end).
+        (chunk_start, chunk_end) are the bytes that you would need to extract from the xml.bz2 file to find the chunk
+        containing a given page. Note that chunks may contain more than one article.
+
+        Store the current chunk region and titles in a buffer, when we find a new chunk we know the beginning 
+        and end of the previous chunk so we can add them to the dictionary.
+        """
+        buffer_region_start = 0
+        buffer_titles = []
+        with open(self.index_file, "r") as index_file:
+            for line in index_file:
+                [line_region_start, _id, *split_name] = line.split(":")
+                line_article_name = ":".join(split_name).strip()
+                if line_region_start != buffer_region_start:
+                    for name in buffer_titles:
+                        self.articles[name] = (int(buffer_region_start), int(line_region_start))
+                    buffer_region_start = line_region_start
+                    buffer_titles = []
+                buffer_titles.append(line_article_name)
+        for name in buffer_titles:
+            self.articles[name] = (int(buffer_region_start), int(self.xml_file_size))
+
+    def load(self):
+        """
+        Load the wikipedia index file into memory.
+        If an articles.pickle.tmp exists, we simply load that (~12 seconds)
+        If the pickle file doesn't exist, we manually load the index by parsing the text file (~43 seconds)
+        """
+        try:
+            with open("articles.pickle.tmp", "rb") as articles_pickle_file:
+                log.debug("Using pickled article file")
+                self.articles = pickle.load(articles_pickle_file)
+        except:
+            log.debug("Unable to used pickled articles, doing a manual load of the index file")
+            self.manual_load()
+            with open("articles.pickle.tmp", "wb") as articles_pickle_file:
+                log.debug("Saving articles as a pickled dump to speed up future loads")
+                pickle.dump(self.articles, articles_pickle_file)
+    
+    def get_range(self, title):
+        """
+        Find the range of bytes for a given article based on the title.
+
+        Returns (start, end) in bytes of the bzipped xml file
+        """
+        return self.articles[title]
+
+    def page_exists(self, title):
+        """
+        Return True IFF the article exists in the dictionary
+        """
+        return title in self.articles.keys()
+        
+
+class LocalWikipediaApi(IWikiApi):
+    def __init__(self, index_file, bz_xml_file):
+        self.index_file = WikipediaIndexFile(index_file, getsize(bz_xml_file))
+        self.bz_xml_file = bz_xml_file
+
+    def load(self):
+        """
+        Loads the index file into memory.
+        Will potentially block the main thread for a little under a minute.
+        Must be called before using this API.
+        """
+        self.index_file.load()
+
+    def get_page_chunk(self, title):
+        """
+        Load the XML chunk from the bz_xml_file based on the indexes in the index file.
+        Returns the text of the chunk.
+        """
+        (start, end) = self.index_file.get_range(title)
+        length = end - start
+        with open(self.bz_xml_file, "rb") as bz_xml_file:
+            bz_xml_file.seek(start)
+            chunk = bz_xml_file.read(length)
+        xml = bz2.decompress(chunk)
+        return xml
+
+    def get_page_wikitext(self, title):
+        """
+        Get the wikitext for a given page
+        """
+        chunk = self.get_page_chunk(title)
+
+        # Need to wrap the page fragments in a parent to make it valid xml
+        chunk_xml = xml.fromstring("<pages>" + chunk.decode('utf-8') + "</pages>")
+
+        # Find the correct page
+        pages = chunk_xml.findall("page")
+        for page in pages:
+            if page.find("title").text == title:
+                correctPage = page
+
+        # Return the text of the correct page
+        return correctPage.find("./revision/text").text
+
+    def get_parsed_page(self, title):
+        """
+        Return the mwparserfromhell parsed page for the given title
+        """
+        parsed = mwparserfromhell.parse(self.get_page_wikitext(title))
+        return parsed
+
+    def page_exists(self, title):
+        """ 
+        Return True IFF the page exists
+        """
+        return self.index_file.page_exists(title)
+
+    def is_redirect_page(self, title):
+        """
+        Returns True IFF the page is a redirect page
+        
+        From Wikipedia (https://en.wikipedia.org/wiki/Help:Redirect):
+        A page is treated as a redirect page if its wikitext begins with #REDIRECT followed by a valid wikilink or interwikilink. 
+        A space is usually left before the link. (Note that some alternative capitalizations of "REDIRECT" are possible.)
+        """
+        return "#redirect" in self.get_page_wikitext(title).lower()
+
+    def get_redirect_target(self, title):
+        """
+        Returns the target of a wikipedia redirect page. This is the target of the first link on the page.
+        
+        From Wikipedia:
+        A page is treated as a redirect page if its wikitext begins with #REDIRECT followed by a valid wikilink or interwikilink. 
+        A space is usually left before the link. (Note that some alternative capitalizations of "REDIRECT" are possible.)
+        """
+        parsed = self.get_parsed_page(title)
+        links = parsed.ifilter_wikilinks(recursive=False) # We don't need recursion here since the redirect must be the first thing on the page
+        link = list(itertools.islice(links, 1))[0] # Weird syntax because links is a generator and it's not trivial to get the first element of a generator
+        link_target = link.title.strip_code().split("#")[0]
+        return link_target
+
+    def get_random_page(self):
+        """
+        Return a random page
+        Not implemented yet
+        """
+        raise Error("Method not implemented yet! If you need it, :bee: :change:")
+
+    def get_summaries(self, titles):
+        """
+        Bulk fetch summaries for a list of titles
+        :param titles: A list of article titles
+        :return: A dict of titles to summary strings
+
+        Follows redirects
+
+        For now, the local wikipedia api just returns the entire page. :bee: :change:
+        """
+        return {title: self.get_text_and_links(self.get_canonical_name(title))[0] for title in titles}
+
+    def get_text_and_links(self, title):
+        """
+        Return a tuple of (article text, link targets)
+
+        Follows redirects
+        """
+        parsed = self.get_parsed_page(self.get_canonical_name(title))
+        text = parsed.strip_code()
+        links = parsed.ifilter_wikilinks(recursive=True)
+        unique_links = set([link.title.strip_code().split("#")[0] for link in links])
+        return text, unique_links
+    
+    def get_name_variants(self, title):
+        """
+        Get potential variants for a title
+        
+        Eg, on input: A joUrNey tO WonderLAND
+        - uppercase: A JOURNEY TO WONDERLAND
+        - lowercase: a journey to wonderland
+        - naive titlecase: A Journey To Wonderland
+        - accurate titlecase: A Journey to Wonderland
+
+        Returns a list of the variants
+        """
+        return [title.upper(), title.lower(), title.title(), titlecase(title)]
+
+    def get_canonical_name(self, title, try_naming_variants=True):
+        """
+        Get the official name of an article. Useful because we just check string equality for the goal test,
+        so we don't want to skip over the goal if e.g. the capitalization is off
+        :return: The canonical name of the given page
+
+        If try_naming_variants is true, attempt to try other capitalizations of the name.
+        This should be on most times, but not when we recur during the process of autocapitalization.
+
+        Cases:
+        - The article name is correct
+            - Use the article title as is
+        - The article is a redirection page
+            - Recursively call get_canonical_name on the redirect target
+        - The article doesn't exist
+            - Attempt to perform auto capitalization on the title to see if any of those pages exist, in which case recur on them
+            - If all fails, raise IOError
+        """
+        if self.page_exists(title):
+            if self.is_redirect_page(title):
+                return self.get_canonical_name(self.get_redirect_target(title))
+            else:
+                return title
+        else:
+            if try_naming_variants:
+                for variant in self.get_name_variants(title):
+                    try:
+                        return self.get_canonical_name(variant, try_naming_variants=False)
+                    except IOError:
+                        continue
+            raise IOError("{} not a valid page title".format(title))

--- a/LocalApi.py
+++ b/LocalApi.py
@@ -1,6 +1,6 @@
 import logging
 import bz2
-import pickletools
+import pickle
 import itertools
 import xml.etree.ElementTree as xml
 import mwparserfromhell
@@ -62,7 +62,7 @@ class WikipediaIndexFile:
                 log.debug("Using pickled article file")
                 self.articles = pickle.load(articles_pickle_file)
         except:
-            log.debug("Unable to used pickled articles, doing a manual load of the index file")
+            log.debug("Unable to use pickled articles, doing a manual load of the index file")
             self.manual_load()
             with open("articles.pickle.tmp", "wb") as articles_pickle_file:
                 log.debug("Saving articles as a pickled dump to speed up future loads")

--- a/Search.py
+++ b/Search.py
@@ -5,8 +5,8 @@ log = logging.getLogger(__name__)
 
 
 class Search:
-    def __init__(self, get_content_and_neighbors, heuristic):
-        self.get_content_and_neighbors = get_content_and_neighbors
+    def __init__(self, api, heuristic):
+        self.api = api
         self.heuristic = heuristic
 
     def a_star(self, start, goal):
@@ -22,7 +22,9 @@ class Search:
             visited.add(node)
             if node == goal:
                 return path, nodes_expanded
-            content, neighbors = self.get_content_and_neighbors(node)
+            if not self.api.is_valid_article(node):
+                continue
+            content, neighbors = self.api.get_text_and_links(node)
             nodes_expanded += 1
             log.debug("Got {} neighbors for {}: {}".format(len(neighbors),
                                                            node,

--- a/WikiAgent.py
+++ b/WikiAgent.py
@@ -2,9 +2,9 @@ import Search
 
 class WikiAgent:
     def __init__(self, api):
-        self.wikipedia_api = api
+        self.api = api
 
     def search(self, start, end, heuristic):
-        search = Search.Search(self.wikipedia_api.get_text_and_links,
+        search = Search.Search(self.api,
                                heuristic)
         return search.a_star(start, end)

--- a/WikiAgent.py
+++ b/WikiAgent.py
@@ -1,10 +1,8 @@
 import Search
-import WikipediaApi
-
 
 class WikiAgent:
-    def __init__(self):
-        self.wikipedia_api = WikipediaApi.WikipediaApi()
+    def __init__(self, api):
+        self.wikipedia_api = api
 
     def search(self, start, end, heuristic):
         search = Search.Search(self.wikipedia_api.get_text_and_links,

--- a/WikiRacer.py
+++ b/WikiRacer.py
@@ -8,12 +8,21 @@ import sys
 
 import HeuristicTester
 import Heuristics
-import WikipediaApi
+from WikipediaApi import WikipediaApi
+from LocalApi import LocalWikipediaApi as LocalApi
+
+APIs = {
+    "WikipediaApi": WikipediaApi,
+    "LocalApi": LocalApi
+}
 
 log = logging.getLogger(__name__)
 
 def getValidHeuristics():
     return list(filter(lambda x: x[0] != "_", dir(Heuristics))) # filter out dunder methods
+
+def getValidAPIs():
+    return APIs.keys()
 
 def parse(argv):
     parser = argparse.ArgumentParser(description="Find a path between Wikipedia pages with the given heuristic",
@@ -24,6 +33,9 @@ def parse(argv):
     parser.add_argument("--quiet", "-q", help="Create fewer log messages", action="count")
     parser.add_argument("--no-console", help="Disable console logging", action="store_true")
     parser.add_argument("--no-file", help="Disable file logging", action="store_true")
+    parser.add_argument("--api", help="The api to use. One of {}".format(getValidAPIs()), default="WikipediaApi")
+    parser.add_argument("--local-bz", help="The path to the *-multistream.xml.bz file from the wikipedia dump")
+    parser.add_argument("--local-index", help="The path to the *-index.txt file from the wikipedia dump")
 
     return parser.parse_args(argv[1:])
 
@@ -49,18 +61,35 @@ def initialize_logger(arguments):
         level=level,
         handlers=handlers)
 
+def initialize_api(arguments):
+    if arguments.api == "LocalApi":
+        if not arguments.local_index or not arguments.local_bz:
+            log.error("--local-bz and --local-index arguments must be provided when using the LocalApi")
+            raise ValueError("Cannot construct LocalApi")
+        api = LocalApi(arguments.local_index, arguments.local_bz)
+    else:
+        api = APIs[arguments.api]() if arguments.api in APIs else None
+
+        if api is None:
+            log.error("{} is not a valid api. Options: {}".format(arguments.api, getValidAPIs()))
+            raise ValueError("Invalid api")
+
+    api.load()
+
+    return api
 
 def run_search(arguments):
     heuristic = getattr(Heuristics, arguments.heuristic, None)
+
+    api = initialize_api(arguments)
 
     if heuristic is None:
         log.error("{} is not a valid heuristic. Options: {}".format(arguments.heuristic, getValidHeuristics()))
         raise ValueError("Invalid heuristic")
 
-    api = WikipediaApi.WikipediaApi()
     start = api.get_canonical_name(arguments.start)
     goal = api.get_canonical_name(arguments.goal)
-    HeuristicTester.HeuristicTester.compare_heuristics(start, goal, heuristic)
+    HeuristicTester.HeuristicTester.compare_heuristics(start, goal, api, heuristic)
 
 
 if __name__ == "__main__":

--- a/WikipediaApi.py
+++ b/WikipediaApi.py
@@ -3,6 +3,7 @@ import logging
 from queue import Queue
 from threading import Thread
 from time import time
+from IWikiApi import IWikiApi
 
 import requests
 from bs4 import BeautifulSoup
@@ -11,7 +12,7 @@ log = logging.getLogger(__name__)
 logging.getLogger("urllib3.connectionpool").setLevel(logging.ERROR)  # Don't want these requests filling the logs
 
 
-class WikipediaApi:
+class WikipediaApi(IWikiApi):
     def __init__(self):
         self.api_root = "https://en.wikipedia.org/api/rest_v1/"
         self.headers = {'User-Agent': 'wong.mich@husky.neu.edu'}  # Wikipedia asks to provide contact info in user agent

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 bs4
 requests
+mwparserfromhell
+titlecase


### PR DESCRIPTION
Solves #11 
# Changes
Implements local API
Adds an API interface
Adds API flags to the WikiRacer.py script
Passes API to search

# Usage
`./WikiRacer.py cattle cow --heuristic bfs_heuristic --api LocalApi --local-bz ./data/enwiki-20181020-pages-articles-multistream.xml.bz2 --local-index ./data/enwiki-20181020-pages-articles-multistream-index.txt`

# Issues
It tends to get stuck in an infinite recursion loop in `get_canonical_name`

There are a few weird bugs left over, although right now I'm unsure if they are issues with the data dump or my python code. Trying to load the chunk for `Possible world` results in an invalid bz2 file. It'll require further investigation, but when I tried to replicate the extraction process manually, I also got an invalid bz2 file which is suspicious. Then the second trime I tried to replicate it it worked, so maybe I'm actually crazy. I'll have to look into this again.

Ignore this:
```
Note entry for "Possible world" on line 464936 of the index:
1458567660:780566:Possible world
And the beginning of the next chunk on line 465001:
1458689481:780670:KIRO (AM)

Therefore we should extract the chunk from 1458567660 to 1458689481 of the bz2 file. 
length = 1458689481 - 1458567660 = 121821

kevin@raikou:/hdd/WikiRacer/data$ dd if=enwiki-20181020-pages-articles-multistream.xml.bz2 of=tmp.xml.bz2 skip=1458567660 count=121821 iflag=skip_bytes,count_bytes
237+1 records in
237+1 records out
121821 bytes (122 kB, 119 KiB) copied, 0.0149785 s, 8.1 MB/s
kevin@raikou:/hdd/WikiRacer/data$ file tmp.xml.bz2 
tmp.xml.bz2: bzip2 compressed data, block size = 900k
kevin@raikou:/hdd/WikiRacer/data$ bunzip2 tmp.xml.bz2 

It worked this time, not sure why. I must have messed up the first time. Still doing the same thing in the python code with the seeking and reading leads to getting an empty chunk.
```

It looks like it also got stuck on `bat` for some reason.