### PR TITLE
Fixed an infinite waiting bug in the summary tasks

### DIFF
--- a/src/apis/WikipediaApi.py
+++ b/src/apis/WikipediaApi.py
@@ -96,8 +96,8 @@ class WikipediaApi(AWikiApi):
                     self.queue.task_done()
                 else:
                     url = self.api_root + "page/summary/" + urllib.parse.quote(title, safe='')
-                    response = requests.get(url, headers=self.headers)
                     try:
+                        response = requests.get(url, headers=self.headers)
                         if response.status_code == 200:
                             summary = json.loads(response.text)["extract"]
                             self.results[title] = summary


### PR DESCRIPTION
The requests call should be inside the try call so that we always complete our task 